### PR TITLE
Allow users to specify datasets as numpy arrays

### DIFF
--- a/ml_privacy_meter/utils/attack_data.py
+++ b/ml_privacy_meter/utils/attack_data.py
@@ -22,19 +22,18 @@ def get_tfdataset(features, labels):
     return tf.data.Dataset.from_tensor_slices((features, labels))
 
 
-class attack_data:
+class AttackData:
     """
     Attack data class to perform operations on dataset.
     """
 
-    def __init__(self, dataset_path, member_dataset_path, batch_size,
-                 attack_percentage, normalization=False,
-                 input_shape=None):
+    def __init__(self, x_population, y_population, x_target_train, y_target_train,
+                 batch_size, attack_percentage, normalization=False, input_shape=None):
 
         self.batch_size = batch_size
 
         # Loading the training (member) dataset
-        self.train_data = np.load(member_dataset_path)
+        self.train_data = self._convert_to_prev_extracted_format(x_target_train, y_target_train)
         self.training_size = len(self.train_data)
 
         self.attack_size = int(attack_percentage /
@@ -46,7 +45,7 @@ class attack_data:
         self.normalization = normalization
 
         # Loading and shuffle the dataset
-        self.dataset = self._extract(dataset_path)
+        self.dataset = self._convert_to_prev_extracted_format(x_population, y_population)
         np.random.shuffle(self.dataset)
 
         self.input_channels = self.input_shape[-1]
@@ -65,6 +64,41 @@ class attack_data:
         with open(filepath, "r") as f:
             dataset = f.readlines()
         dataset = list(map(lambda i: i.strip('\n').split(';'), dataset))
+        dataset = np.asarray(dataset)
+        return dataset
+
+    def _convert_to_prev_extracted_format(self, x, y):
+        """
+        Utility to convert numpy array dataset to the previous data format.
+        This is so that we can use the same attack code with numpy array datasets,
+        and particularly because hashing is used for making sure member and
+        non-member datasets do not overlap.
+        Note: this workflow should be revamped in the upgrade.
+        """
+        dataset_len = len(x)
+        dataset = []
+        for idx in range(dataset_len):
+            # features
+            row_x = x[idx]
+            row_x_shape = row_x.shape
+            row = []
+            if len(row_x_shape) > 1:
+                # image data
+                num_channels = row_x_shape[-1]  # assumes HWC i.e. channels last format
+                for channel_idx in range(num_channels):
+                    channel_row_x = row_x[:, :, channel_idx].flatten()
+                    channel_row_x = channel_row_x.tolist()
+                    row.append(",".join(str(item) for item in channel_row_x))  # needs to be a string separated by ","
+            else:
+                # tabular data
+                row.append(",".join(str(item) for item in row_x))  # list of features
+
+            # labels
+            row_y = y[idx]
+            row.append(row_y)
+
+            dataset.append(row)
+
         dataset = np.asarray(dataset)
         return dataset
 

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -9,19 +9,57 @@ Following are the descriptions of the files.
 ## Running the Alexnet CIFAR-100 Attack
 To perform an attack as in Nasr et al [2], we use the Alexnet model trained on the CIFAR-100 dataset. We perform the whitebox attack on the model while exploiting the gradients, final layer outputs, loss values and label values.
 First, extract the pretrained model from the `tutorials/models` directory and place it in the root directory of the project. `unzip tutorials/models/alexnet_pretrained.zip -d .`
-Note : The user can also train their own model to attack simliar to the example in `tutorials/alexnet.py`
-Then, run the script to download the required data files.
+
+Note: The user can also train their own model to attack simliar to the example in `tutorials/alexnet.py`
+
+The following libraries need to be imported for this tutorial.
+
+```python
+import tensorflow as tf
+import numpy as np
+import ml_privacy_meter
 ```
-cd datasets
-chmod +x download_cifar100.sh
-./download_cifar100.sh
+
+To use the CIFAR100 dataset in Tensorflow, add code similar to this in your script.
+
+```python
+def preprocess_cifar100_dataset():
+    input_shape = (32, 32, 3)
+    num_classes = 100
+
+    # Split the data between train and test sets
+    (x_train, y_train), (x_test, y_test) = tf.keras.datasets.cifar100.load_data()
+
+    return x_train, y_train, x_test, y_test, input_shape, num_classes
+    
+x_train, y_train, x_test, y_test, input_shape, num_classes = preprocess_cifar100_dataset()
 ```
-This downloads the dataset file and training set file and converts them into the format required by the tool.
-We then run the attack code `python tutorials/attack_alexnet.py`. 
-The `attackobj` initializes the meminf class and the attack configuration. Following are some examples of configurations that can be changed in the function.
-Note : The code explicitly sets the means and standard deviations for normalizing the images, according to the CIFAR-100 distribution.
+
+Next, we initialize the datahandler required by the tool.
+
+```python
+num_datapoints = 5000  # example of the train dataset size
+x_target_train, y_target_train = x_train[:num_datapoints], y_train[:num_datapoints]
+
+# population data (training data is a subset of this here)
+x_population = np.concatenate((x_train, x_test))
+y_population = np.concatenate((y_train, y_test))
+
+datahandlerA = ml_privacy_meter.utils.attack_data.AttackData(x_population=x_population,
+                                                             y_population=y_population,
+                                                             x_target_train=x_target_train,
+                                                             y_target_train=y_target_train,
+                                                             batch_size=100,
+                                                             attack_percentage=10, input_shape=input_shape,
+                                                             normalization=True)
+```
+
+We can then specify the configuration of the attack that will be performed by the tool. The `attackobj` initializes the meminf class and the attack configuration. Following are some examples of configurations that can be customized.
+
+Note: The code in the tutorial explicitly sets the means and standard deviations for normalizing the images, according to the CIFAR-100 distribution.
+
 1. Whitebox attack - Exploit the final layer gradients, final layer outputs, loss values and label values (DEFAULT)
-```
+```python
 attackobj = ml_privacy_meter.attack.meminf.initialize(
     target_train_model=cmodelA,
     target_attack_model=cmodelA,
@@ -31,8 +69,9 @@ attackobj = ml_privacy_meter.attack.meminf.initialize(
     gradients_to_exploit=[6],
     device=None)
 ```
+
 2. Whitebox attack - Exploit final two model layer outputs, loss values and label values
-```
+```python
 attackobj = ml_privacy_meter.attack.meminf.initialize(
     target_train_model=cmodelA,
     target_attack_model=cmodelA,
@@ -41,8 +80,9 @@ attackobj = ml_privacy_meter.attack.meminf.initialize(
     layers_to_exploit=[22, 26],
     device=None)
 ```
-2. Blackbox attack - Exploit final layer output and label values
-```
+
+3. Blackbox attack - Exploit final layer output and label values
+```python
 attackobj = ml_privacy_meter.attack.meminf.initialize(
     target_train_model=cmodelA,
     target_attack_model=cmodelA,
@@ -52,3 +92,5 @@ attackobj = ml_privacy_meter.attack.meminf.initialize(
 	exploit_loss=False,
     device=None)
 ```
+
+The desired attack code can be run using the command `python tutorials/attack_alexnet.py`.

--- a/tutorials/attack_alexnet.py
+++ b/tutorials/attack_alexnet.py
@@ -2,11 +2,6 @@ import numpy as np
 
 import ml_privacy_meter
 import tensorflow as tf
-import tensorflow.compat.v1.keras.layers as keraslayers
-from tensorflow.compat.v1.train import Saver
-
-# input_features should be changed according to the model
-input_shape = (32, 32, 3)
 
 # Load saved target model to attack
 cprefix = 'alexnet_pretrained'
@@ -14,31 +9,39 @@ cmodelA = tf.keras.models.load_model(cprefix)
 
 cmodelA.summary()
 
-# `saved_path` is required for obtaining the training data that was used to
-# train the target classification model. This is because
-# the datapoints that form the memberset of the training data of the attack
-# model has to be a subset of the training data of target classification model.
-# User can store the training data wherever he/she wants but the only requirement
-# is that the file has to be stored in '.npy' format. The contents should be of
-# the same format as the .txt file of the dataset.
-saved_path = "datasets/cifar100_train.txt.npy"
 
-# Similar to `saved_path` being used to form the memberset for attack model,
-# `dataset_path` is used for forming the nonmemberset of the training data of
-# attack model.
-dataset_path = 'datasets/cifar100.txt'
+def preprocess_cifar100_dataset():
+    input_shape = (32, 32, 3)
+    num_classes = 100
 
-datahandlerA = ml_privacy_meter.utils.attack_data.attack_data(dataset_path=dataset_path,
-                                                              member_dataset_path=saved_path,
-                                                              batch_size=100,
-                                                              attack_percentage=10, input_shape=input_shape,
-                                                              normalization=True)
+    # Split the data between train and test sets
+    (x_train, y_train), (x_test, y_test) = tf.keras.datasets.cifar100.load_data()
+
+    return x_train, y_train, x_test, y_test, input_shape, num_classes
+
+
+x_train, y_train, x_test, y_test, input_shape, num_classes = preprocess_cifar100_dataset()
+
+# training data of the target model
+num_datapoints = 5000
+x_target_train, y_target_train = x_train[:num_datapoints], y_train[:num_datapoints]
+
+# population data (training data is a subset of this)
+x_population = np.concatenate((x_train, x_test))
+y_population = np.concatenate((y_train, y_test))
+
+datahandlerA = ml_privacy_meter.utils.attack_data.AttackData(x_population=x_population,
+                                                             y_population=y_population,
+                                                             x_target_train=x_target_train,
+                                                             y_target_train=y_target_train,
+                                                             batch_size=100,
+                                                             attack_percentage=10, input_shape=input_shape,
+                                                             normalization=True)
 
 
 # Set means and standard deviations for normalization.
 # If unset, they are calculated from the dataset.
-datahandlerA.means, datahandlerA.stddevs = [
-    0.4914, 0.4822, 0.4465], [0.2023, 0.1994, 0.2010]
+datahandlerA.means, datahandlerA.stddevs = [0.4914, 0.4822, 0.4465], [0.2023, 0.1994, 0.2010]
 
 attackobj = ml_privacy_meter.attack.meminf.initialize(
     target_train_model=cmodelA,


### PR DESCRIPTION
Updated the AlexNet tutorial with the new code for dataset handling. 

Thoughts on data handling for the upgrade:
1. Different sources of data that need to be handled: (a) target train and test data, (b) population/aux data for the attack.
2. The target model's data can be a subset of the population data, or have some overlapping data with the population data.
3. So we need to have some way of removing the overlapping data from the population data. Currently we have a buggy way of hashing the string version of the train data and removing these data points from the population data if the same hashes are present. 
4. A better way would be to let the user specify the overlapping data point indices, if there are any. 

Example workflow:

```python
targetDataset = TargetDataset(x_train, y_train, x_test, y_test)
populationDataset = PopulationDataset(x_population, y_population, target_train_indices)
```

Both TargetDataset and PopulationDataset can inherit from a parent Dataset class, which will have the actual tf-datasets code for creating and using a dataset.