### PR TITLE
fix rmia code link from the rmia paper

### DIFF
--- a/research/2024_rmia/README.md
+++ b/research/2024_rmia/README.md
@@ -1,0 +1,2 @@
+# Low-Cost High-Power Membership Inference Attacks
+Code is available at https://github.com/privacytrustlab/ml_privacy_meter/blob/d32734161a3395211fe5f3cd461932290b1fafbe/research/2024_rmia.


### PR DESCRIPTION
Created the 2024_rmia folder so that the link from rmia's icml paper and the issue https://github.com/privacytrustlab/ml_privacy_meter/issues/131 still works