### PR TITLE
DUCI: add mia module and duci module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ Machine learning is playing a central role in automated decision-making in a wid
 
 Data Protection regulations, such as GDPR and AI governance frameworks, require personal data to be protected when used in AI systems, and that the users have control over their data and awareness about how it is being used. For example, [Article 35 of GDPR](https://gdpr-info.eu/art-35-gdpr/) requires organizations to systematically analyze, identify and minimize the data protection risks of a project, especially when the project involves innovative technologies such as Artificial Intelligence, Machine Learning, and Deep Learning. Thus, proper mechanisms need to be in place to quantitatively evaluate and verify the privacy of individuals in every step of the data processing pipeline in AI systems.
 
+## Functionality
+Privacy Meter supports auditing the privacy risk of ML models with different privacy notions. This is done by supporting multiple inference attacks:
+1. Membership inference attack (MIA)
+2. Range membership inference attack (RaMIA)
+3. Dataset usage cardinality inference attack (DUCI)
+
+It also supports auditing differentially private (DP) algorithms and models with any of these attacks above.
+
+### Applicable model classes and their tasks
+Privacy Meter supports various model classes. By default, we support MLPs and WideResNets for classification tasks. We also support LLMs for text generation.
+
 ## Overview
 Privacy Meter supports different types of models, datasets and privacy games, which all need to be specified in a `.yaml` configuration file. The description of the configuration file can be found [here](configs/README.md).
 
@@ -51,6 +62,7 @@ conda env create -f env.yaml
 ```
 This should create a conda environment named `privacy_meter` and install all necessary libraries in it. If conda takes too much time (more than a few minutes) to solve the environment, we suggest updating the conda default solver by following this official [article](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community).
 
+### Membership inference attacks
 To run our demo, you can use the following command
 
 ```
@@ -60,6 +72,13 @@ python main.py --cf configs/config.yaml
 The `.yaml` file allows you to specify the hyperparameters for training the model, and the details of the membership inference attack. To shorten the time to run the demo, we set the number of epochs to 10. To properly audit the privacy risk, we suggest change the number of epochs to 100 or whatever is appropriate for your use case.
 
 For a comprehensive explanation of each parameter, please refer to each `.yaml` file and the explanation [here](configs/README.md). You can also refer to the [demo notebook](demo.ipynb) for a step-by-step walkthrough. Upon audit completion, you will find the results in the `demo` folder, with the attack results saved in `demo/report`. Furthermore, we also offer a timing log for each run, which can be found in the file `log_time_analysis.log`. We recommend running each new set of experiments with different hyperparameters under a different `log_dir` to avoid misusing old trained models or losing previous results.
+
+### Range membership inference attacks
+To audit privacy using range membership inference, you can use the following command
+```
+python run_range_mia.py --cf configs/config_range.yaml
+```
+Note there should be some extra fields in the configuration file for RaMIA compared to MIA that specifies the range attack.
 
 ### Supported dataset and models by default
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,20 @@ Below is the high level pipeline of the internal mechanism of Privacy Meter, whi
 flowchart LR
     H["**Load Dataset**"] --> J["**Load or Train Models**"]
     J --> L["**Gather Auditing Dataset**"]
-    L --> M["**Generate Membership Signals**"]
+    L --> M["**Compute Membership Signals**"]
     M --> O["**Perform Privacy Audit**"]
 ```
 
+For **Range membership inference**, we modify the pipeline in auditing dataset creation by replacing each point query to range query. In the signal computation step, samples are taken in each range query, before their signals are aggregated in the new signal aggregation step to create the RangeMIA score. Below is the flowchart for RaMIA:
+
+```mermaid
+flowchart LR
+    H["**Load Dataset**"] --> J["**Load or Train Models**"]
+    J --> L["**Create Range Auditing Dataset**"]
+    L --> M["**Compute Membership Signals**"]
+    M -- >N["**Aggregate Signals in Each Range**"]
+    N --> O["**Perform Privacy Audit**"]
+```
 
 ## User Manual
 ### Getting started

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ flowchart LR
     H["**Load Dataset**"] --> J["**Load or Train Models**"]
     J --> L["**Create Range Auditing Dataset**"]
     L --> M["**Compute Membership Signals**"]
-    M -- >N["**Aggregate Signals in Each Range**"]
+    M --> N["**Aggregate Signals in Each Range**"]
     N --> O["**Perform Privacy Audit**"]
 ```
 

--- a/attacks.py
+++ b/attacks.py
@@ -73,8 +73,10 @@ def tune_offline_a(
         if roc_auc > max_auc:
             max_auc = roc_auc
             offline_a = test_a
+            mia_scores_array = mia_scores.ravel().copy()
+            membership_array = paired_memberships.ravel().copy()
         logger.info(f"offline_a={test_a:.2f}: AUC {roc_auc:.4f}")
-    return offline_a
+    return offline_a, mia_scores_array, membership_array
 
 
 def run_rmia(

--- a/attacks.py
+++ b/attacks.py
@@ -34,6 +34,7 @@ def get_rmia_out_signals(
     selected_signals = all_signals[:, columns]
     non_members = ~all_memberships[:, columns]
     out_signals = selected_signals * non_members
+    # Sort the signals such that only the non-zero signals (out signals) are kept
     out_signals = -np.sort(-out_signals, axis=1)[:, :num_reference_models]
     return out_signals
 

--- a/configs/agnews_range.yaml
+++ b/configs/agnews_range.yaml
@@ -1,0 +1,41 @@
+run: # Configurations for a specific run
+  random_seed: 12345 # Integer number of specifying random seed
+  log_dir: demo_agnews # String for indicating where to save all the information, including models and computed signals. We can reuse the models saved in the same log_dir.
+  time_log: True # Indicate whether to log the time for each step
+  num_experiments: 1 # Number of total experiments
+
+audit: # Configurations for auditing
+  privacy_game: privacy_loss_model # Indicate the privacy game from privacy_loss_model
+  algorithm: RMIA # String for indicating the membership inference attack. We currently support the RMIA introduced by Zarifzadeh et al. 2024(https://openreview.net/pdf?id=sT7UJh5CTc)) and the LOSS attacks
+  num_ref_models: 1 # Number of reference models used to audit each target model
+  device: cuda:0 # String for indicating the device we want to use for inferring signals and auditing models
+  report_log: report_rmia # String that indicates the folder where we save the log and auditing report
+  batch_size: 20 # Integer number for indicating batch size for evaluating models and inferring signals.
+
+train: # Configuration for training
+  model_name: gpt2 # String for indicating the model type. We support CNN, wrn28-1, wrn28-2, wrn28-10, vgg16, mlp, gpt2 and speedyresnet (requires cuda). More model types can be added in model.py.
+  tokenizer: gpt2 # String for indicating the tokenizer type. It can be any tokenizer or local checkpoint supported by the transformers library.
+  device: cuda:0 # String for indicating the device we want to use for training models.
+  batch_size: 8
+  learning_rate: 0.00005
+  weight_decay: 0.01
+  epochs: 1
+  optimizer: adamw_torch
+#  peft: # configuration for peft
+#    type: lora # Specify finetuning method
+#    fan_in_fan_out: True
+#    r: 16
+#    target_modules: ["c_attn", "c_proj", "c_fc"]
+
+ramia:
+  range_function: word_replace
+  sample_size: 5
+  mask_model: bert-base-uncased
+  mask_tokenizer: bert-base-uncased
+  num_masks: 5
+
+data: # Configuration for data
+  dataset: agnews # String indicates the name of the dataset. We support cifar10, cifar100, purchase100 and texas100 and agnews by default.
+  data_dir: data
+  tokenize: True
+  tokenizer: gpt2 # String for indicating the tokenizer type. It can be any tokenizer or local checkpoint supported by the transformers library.

--- a/configs/cifar10.yaml
+++ b/configs/cifar10.yaml
@@ -31,7 +31,7 @@ train: # Configuration for training
   optimizer: SGD
   learning_rate: 0.1
   weight_decay: 0
-  epochs: 3
+  epochs: 100
 
 data: # Configuration for data
   dataset: cifar10 # String indicates the name of the dataset. We support cifar10, cifar100, purchase100 and texas100 by default.

--- a/configs/cifar10_range.yaml
+++ b/configs/cifar10_range.yaml
@@ -1,6 +1,6 @@
 run: # Configurations for a specific run
   random_seed: 12345 # Integer number of specifying random seed
-  log_dir: demo_purchase # String for indicating where to save all the information, including models and computed signals. We can reuse the models saved in the same log_dir.
+  log_dir: demo_cifar10 # String for indicating where to save all the information, including models and computed signals. We can reuse the models saved in the same log_dir.
   time_log: True # Indicate whether to log the time for each step
   num_experiments: 1 # Number of total experiments
 
@@ -10,11 +10,11 @@ audit: # Configurations for auditing
   num_ref_models: 1 # Number of reference models used to audit each target model
   device: cuda:0 # String for indicating the device we want to use for inferring signals and auditing models
   report_log: report_rmia # String that indicates the folder where we save the log and auditing report
-  batch_size: 5 # Integer number for indicating batch size for evaluating models and inferring signals.
+  batch_size: 5000 # Integer number for indicating batch size for evaluating models and inferring signals.
   data_size: 10000 # Integer number for indicating the size of the dataset in auditing. If not specified, the entire dataset is used.
 
 train: # Configuration for training
-  model_name: mlp # String for indicating the model type. We support CNN, wrn28-1, wrn28-2, wrn28-10, vgg16, mlp and speedyresnet (requires cuda). More model types can be added in model.py.
+  model_name: wrn28-2 # String for indicating the model type. We support CNN, wrn28-1, wrn28-2, wrn28-10, vgg16, mlp and speedyresnet (requires cuda). More model types can be added in model.py.
   device: cuda:0 # String for indicating the device we want to use for training models.
   batch_size: 256
   optimizer: SGD
@@ -23,10 +23,10 @@ train: # Configuration for training
   epochs: 100
 
 ramia:
-    range_function: l2
-    sample_size: 10
-    radius: 10
+  range_function: geometric
+  sample_size: 4
+  transformations: [horizontal_flip, vertical_flip, rotate]
 
 data: # Configuration for data
-  dataset: purchase100 # String indicates the name of the dataset. We support cifar10, cifar100, purchase100 and texas100 by default.
+  dataset: cifar10 # String indicates the name of the dataset. We support cifar10, cifar100, purchase100 and texas100 by default.
   data_dir: data

--- a/configs/purchase.yaml
+++ b/configs/purchase.yaml
@@ -20,7 +20,7 @@ train: # Configuration for training
   optimizer: SGD
   learning_rate: 0.1
   weight_decay: 0
-  epochs: 3
+  epochs: 100
 
 data: # Configuration for data
   dataset: purchase100 # String indicates the name of the dataset. We support cifar10, cifar100, purchase100 and texas100 by default.

--- a/configs/purchase_range.yaml
+++ b/configs/purchase_range.yaml
@@ -20,11 +20,11 @@ train: # Configuration for training
   optimizer: SGD
   learning_rate: 0.1
   weight_decay: 0
-  epochs: 3
+  epochs: 100
 
 ramia:
     range_function: l2
-    sample_size: 2
+    sample_size: 10
     radius: 20
 
 data: # Configuration for data

--- a/configs/purchase_range.yaml
+++ b/configs/purchase_range.yaml
@@ -1,6 +1,6 @@
 run: # Configurations for a specific run
   random_seed: 12345 # Integer number of specifying random seed
-  log_dir: demo # String for indicating where to save all the information, including models and computed signals. We can reuse the models saved in the same log_dir.
+  log_dir: demo_purchase # String for indicating where to save all the information, including models and computed signals. We can reuse the models saved in the same log_dir.
   time_log: True # Indicate whether to log the time for each step
   num_experiments: 1 # Number of total experiments
 
@@ -10,18 +10,23 @@ audit: # Configurations for auditing
   num_ref_models: 1 # Number of reference models used to audit each target model
   device: cuda:0 # String for indicating the device we want to use for inferring signals and auditing models
   report_log: report_rmia # String that indicates the folder where we save the log and auditing report
-  batch_size: 5000 # Integer number for indicating batch size for evaluating models and inferring signals.
-#  data_size: 10000 # Integer number for indicating the size of the dataset in auditing. If not specified, the entire dataset is used.
+  batch_size: 5 # Integer number for indicating batch size for evaluating models and inferring signals.
+  data_size: 10000 # Integer number for indicating the size of the dataset in auditing. If not specified, the entire dataset is used.
 
 train: # Configuration for training
-  model_name: wrn28-2 # String for indicating the model type. We support CNN, wrn28-1, wrn28-2, wrn28-10, vgg16, mlp and speedyresnet (requires cuda). More model types can be added in model.py.
+  model_name: mlp # String for indicating the model type. We support CNN, wrn28-1, wrn28-2, wrn28-10, vgg16, mlp and speedyresnet (requires cuda). More model types can be added in model.py.
   device: cuda:0 # String for indicating the device we want to use for training models.
   batch_size: 256
   optimizer: SGD
   learning_rate: 0.1
   weight_decay: 0
-  epochs: 100
+  epochs: 3
+
+ramia:
+    range_function: l2
+    sample_size: 2
+    radius: 20
 
 data: # Configuration for data
-  dataset: cifar10 # String indicates the name of the dataset. We support cifar10, cifar100, purchase100 and texas100 by default.
+  dataset: purchase100 # String indicates the name of the dataset. We support cifar10, cifar100, purchase100 and texas100 by default.
   data_dir: data

--- a/dataset/range_dataset.py
+++ b/dataset/range_dataset.py
@@ -1,0 +1,86 @@
+import torch
+from torch.utils.data import Dataset
+
+from range_samplers import *
+
+
+class RangeSampler:
+    def __init__(self, range_fn: str, sample_size: int, config: dict):
+        self.range_fn = range_fn
+        self.sample_size = sample_size
+        self.config = config
+
+    def sample(self, range_center):
+        if self.sample_size == 1:
+            print("Sample size is 1, returning range center.")
+            return range_center
+        elif self.sample_size < 1:
+            raise ValueError("Sample size must be greater than 0.")
+
+        if self.range_fn == "l2":
+            radius = self.config["ramia"].get("radius", None)
+            if radius is None:
+                raise ValueError("L2 range sampler requires a radius parameter in the config.")
+            return sample_l2(range_center, radius, self.sample_size)
+        elif self.range_fn == "geometric":
+            transformations_list = self.config["ramia"].get("transformations", None)
+            if transformations_list is None:
+                raise ValueError(
+                    "Geometric range sampler requires a transformations parameter in the config."
+                )
+            if len(transformations_list) == 0:
+                raise ValueError("Transformations list cannot be empty.")
+            elif len(transformations_list) != self.sample_size - 1 and len(transformations_list) != self.sample_size:
+                raise ValueError("Transformations list must have length sample_size - 1 or sample_size.")
+            return sample_geometric(range_center, transformations_list, self.sample_size)
+        elif self.range_fn == "word_replace":
+            mask_model = self.config["ramia"].get("mask_model", None)
+            if mask_model is None:
+                raise ValueError(
+                    "Word replace range sampler requires a mask_model parameter in the config."
+                )
+            mask_tokenizer = self.config["ramia"].get("mask_tokenizer", mask_model)
+            num_masks = self.config["ramia"].get("num_masks", None)
+            if num_masks is None:
+                raise ValueError(
+                    "Word replace range sampler requires a num_masks parameter in the config."
+                )
+            device = self.config["ramia"].get("device", "cuda")
+            return sample_word_replace(range_center, mask_model, mask_tokenizer, num_masks, self.sample_size, device)
+        # elif self.range_fn == "ownership":
+        #     ownership_dict_path = self.config["ramia"].get("ownership_dict_path", None)
+        #     if ownership_dict_path is None:
+        #         raise ValueError(
+        #             "Ownership range sampler requires an ownership_dict_path parameter in the config."
+        #         )
+        #     return sample_ownership(range_center, ownership_dict_path, self.sample_size)
+        # elif self.range_fn == "missing_features":
+        #     missing_features = self.config["ramia"].get("missing_features", None)
+        #     if missing_features is None:
+        #         raise ValueError(
+        #             "Missing features range sampler requires a missing_features parameter in the config."
+        #         )
+        #     return sample_missing_features(range_center, missing_features, self.sample_size)
+        else:
+            raise ValueError(f"Range function {self.range_fn} is not supported.")
+
+
+class RangeDataset(Dataset):
+    def __init__(self, dataset: Dataset, sampler: RangeSampler):
+        self.dataset = dataset
+        self.sampler = sampler
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __getitem__(self, idx):
+        try:
+            # Determining if it is a text dataset
+            text = self.dataset.get_text(idx)
+            if self.sampler.range_fn != "word_replace":
+                raise ValueError("Range sampler is not compatible with text data.")
+            range_text = self.sampler.sample(text)
+        except:
+            range_data = self.sampler.sample(self.dataset[idx][0])
+            range_labels = torch.tensor(self.dataset[idx][1], dtype=torch.long).repeat(range_data.shape[0], 1)
+            return torch.tensor(range_data, dtype=torch.float32), range_labels

--- a/get_signals.py
+++ b/get_signals.py
@@ -1,4 +1,5 @@
 import os.path
+import pdb
 from typing import Optional
 
 import numpy as np
@@ -11,13 +12,13 @@ from dataset.utils import load_dataset_subsets
 
 
 def get_softmax(
-        model: PreTrainedModel,
-        samples: torch.Tensor,
-        labels: torch.Tensor,
-        batch_size: int,
-        device: str,
-        temp: float = 1.0,
-        pad_token_id: Optional[int] = None,
+    model: PreTrainedModel,
+    samples: torch.Tensor,
+    labels: torch.Tensor,
+    batch_size: int,
+    device: str,
+    temp: float = 1.0,
+    pad_token_id: Optional[int] = None,
 ) -> np.ndarray:
     """
     Get the model's softmax probabilities for the given inputs and expected outputs.
@@ -42,12 +43,13 @@ def get_softmax(
         batched_labels = torch.split(labels, batch_size)
 
         for x, y in tqdm(
-                zip(batched_samples, batched_labels),
-                total=len(batched_samples),
-                desc="Computing softmax",
+            zip(batched_samples, batched_labels),
+            total=len(batched_samples),
+            desc="Computing softmax",
         ):
             x = x.to(device)
             y = y.to(device)
+            # pdb.set_trace()
 
             pred = model(x)
             if isinstance(model, PreTrainedModel):
@@ -82,12 +84,12 @@ def get_softmax(
 
 
 def get_loss(
-        model: PreTrainedModel,
-        samples: torch.Tensor,
-        labels: torch.Tensor,
-        batch_size: int,
-        device: str,
-        pad_token_id: Optional[int] = None,
+    model: PreTrainedModel,
+    samples: torch.Tensor,
+    labels: torch.Tensor,
+    batch_size: int,
+    device: str,
+    pad_token_id: Optional[int] = None,
 ) -> np.ndarray:
     """
     Get the model's loss for the given inputs and expected outputs.
@@ -145,10 +147,13 @@ def get_model_signals(models_list, dataset, configs, logger):
         signals (np.array): Signal value for all samples in all models
     """
     # Check if signals are available on disk
-    signal_file_name = f"{configs['audit']['algorithm'].lower()}_ramia_signals.npy" if configs.get("ramia",
-                                                                                                   None) else f"{configs['audit']['algorithm'].lower()}_signals.npy"
+    signal_file_name = (
+        f"{configs['audit']['algorithm'].lower()}_ramia_signals.npy"
+        if configs.get("ramia", None)
+        else f"{configs['audit']['algorithm'].lower()}_signals.npy"
+    )
     if os.path.exists(
-            f"{configs['run']['log_dir']}/signals/{signal_file_name}",
+        f"{configs['run']['log_dir']}/signals/{signal_file_name}",
     ):
         signals = np.load(
             f"{configs['run']['log_dir']}/signals/{signal_file_name}",

--- a/module_duci.py
+++ b/module_duci.py
@@ -1,33 +1,39 @@
+from typing import Tuple, List, Any
 import numpy as np
 from sklearn.metrics import roc_curve
 import logging
-from attacks import tune_offline_a, run_rmia, run_loss
 import time
 
-logger = logging.getLogger(__name__)
+import modules.mia
 
 class DUCI:
-    def __init__(self, num_reference_models):
+    def __init__(self, logger: logging.Logger):
         """
         Initialize the DUCI object.
 
         Args:
-            num_reference_models (int): Number of reference models to use.
-            offline_a (float): The offline adjustment parameter.
+            num_reference_models (int): Number of reference models to use. 
+                In DUCI, the real num_reference_models is the number of reference models used. 
+                However, in this implementation, we follow the setting of MIA, i.e., for each
+                sample, num_reference_models reference model is used. Therefore, whne the models are trained
+                with half-half split, the num_reference_models is set to half of the number of reference models.
         """
-        self.num_reference_models = num_reference_models
-        self.offline_a = None
         self.best_threshold = None
         self.tpr = None
         self.fpr = None
+        self.logger = logger
 
-    def pred_proportion(self, target_model_indices, mia_score_list, membership_list, offline_a):
+    def debias_pred(self, 
+            target_model_idx: int,
+            reference_model_indices: np.ndarray,
+            all_signals: np.ndarray,
+            all_memberships: np.ndarray,
+        ) -> Tuple[float, float]:
         """
-        This functions takes in the MIA signals of the target dataset on the target model, 
-        the MIA signals and membership flags over the dataset of reference models to 
-        debias the MIA signals received on the target model. Then, by aggregating the
-        debiased signals, we can make an unbiased prediction to the proportion of dataset 
-        being used in the target model.
+        This functions debiases the MIA signals over the target dataset received on the target model 
+        through reusing the MIA signals and membership flags over the dataset of reference models. Then, 
+        by aggregating the debiased signals, we can make an unbiased prediction to the proportion of 
+        dataset being used in the target model.
 
         The proportion (\hat{p}) is computed as the aggregation of individual estimates (\hat{p}_i) 
         over all data points in the target dataset (X):
@@ -47,134 +53,112 @@ class DUCI:
 
         Args:
             target_model_idx (int): Index of the target model.
-            mia_score_list (np.ndarray): List of signal matrix with shape (samples, models).
-            membership_list (np.ndarray): List of membership matrix with shape (samples, models).
+            mia_scores (np.ndarray): MIA scores for the target model.
+            all_signals (np.ndarray): List of signal matrix with shape (samples, models).
+            all_memberships (np.ndarray): List of membership matrix with shape (samples, models).
 
         Returns:
             dict: A dictionary containing debiased predictions, TPR, FPR, and absolute errors.
         """
-        self.offline_a = offline_a
-        pre_debias_errors, post_debias_errors = [], []
-        for idx, target_model_idx in enumerate(target_model_indices):
-            all_signals = mia_score_list[idx]
-            all_memberships = membership_list[idx]
-            # Identify paired model and reference indices
-            paired_model_idx = target_model_idx + 1 if target_model_idx % 2 == 0 else target_model_idx - 1
-            columns = [
-                i for i in range(all_signals.shape[1])
-                if i != target_model_idx and i != paired_model_idx
-            ][:2 * self.num_reference_models]
+        # Conduct MIA on the target model using privacy meter tools
+        baseline_time = time.time()
+        args = {
+            "attack": "RMIA",
+            "offline_a": None
+        }
+        mia_scores, target_memberships = modules.mia(
+            all_signals, 
+            all_memberships, 
+            target_model_idx, 
+            reference_model_indices, 
+            self.logger, 
+            args
+        )
+        self.logger.info("Collect membership prediction for target dataset on target model %d costs %0.1f seconds",
+            target_model_idx, time.time() - baseline_time,
+        )
 
-            # Select and process reference signals
-            selected_signals = all_signals[:, columns]
-            non_members = ~all_memberships[:, columns]
-            out_signals = selected_signals * non_members
-            out_signals = -np.sort(-out_signals, axis=1)[:, :self.num_reference_models]
-
-            # Compute mean values
-            mean_out_x = np.mean(out_signals, axis=1)
-            mean_x = (1 + self.offline_a) / 2 * mean_out_x + (1 - self.offline_a) / 2
-
-            # De-bias using paired model
-            ref_target_signals = all_signals[:, paired_model_idx]
-            mia_scores_for_debiasing = ref_target_signals / mean_x
-
-            debias_scores = np.array(mia_scores_for_debiasing)
-            debias_memberships = all_memberships[:, paired_model_idx]
-
-            # Find the optimal threshold
-            fpr_list, tpr_list, thresholds = roc_curve(debias_memberships.ravel(), debias_scores.ravel())
-            self.best_threshold = thresholds[np.argmax(tpr_list - fpr_list)]
-            self.tpr = np.max(tpr_list)
-            self.fpr = np.min(fpr_list)
-
-            logger.info(f"Best threshold = {self.best_threshold} (Maximize TPR - FPR) = {self.tpr} - {self.fpr}")
-
-            # Apply threshold to target model scores
-            preds = (all_signals[:, target_model_idx] > self.best_threshold).ravel()
-            target_memberships = all_memberships[:, target_model_idx]
-
-            true_tpr = np.sum(preds * target_memberships.ravel()) / np.sum(target_memberships.ravel())
-            true_fpr = np.sum(preds * ~target_memberships.ravel()) / np.sum(~target_memberships.ravel())
-
-            logger.info(f"Direct aggregation of MIA preds: {np.mean(preds)}, TPR: {true_tpr}, FPR: {true_fpr}")
-
-            # Compute debiased predictions
-            debiased_pres = (preds - self.fpr)/(self.tpr - self.fpr)
-            true_proportion = np.mean(target_memberships)
-            logger.info(f"Debiased aggregation of MIA preds: {np.mean(debiased_pres)}")
-            pre_debias_error = np.abs(np.mean(preds) - true_proportion)
-            post_debias_error = np.abs(np.mean(debiased_pres) - true_proportion)
-            logger.info(
-                r"Absolute Error $| \hat{p} - p|$: Agg MIA = %.4f, Debiased Agg MIA = %.4f",
-                pre_debias_error,
-                post_debias_error
+        # Conduct MIA on the reference model using privacy meter tools
+        ref_score_all, ref_membership_all = [], []
+        for ref_model_idx in reference_model_indices:
+            ref_mia_scores, ref_target_memberships = modules.mia(
+                all_signals,
+                all_memberships,
+                ref_model_idx,
+                reference_model_indices,
+                self.logger,
+                args
             )
-            pre_debias_errors.append(pre_debias_error)
-            post_debias_errors.append(post_debias_error)
+            ref_score_all.append(ref_mia_scores)
+            ref_membership_all.append(ref_target_memberships)
+        debias_memberships = np.array(ref_membership_all)
+        debias_scores = np.array(ref_score_all)
 
-        return pre_debias_errors, post_debias_errors
-    
-    def get_ind_signals(
+        # Find the optimal threshold
+        fpr_list, tpr_list, thresholds = roc_curve(debias_memberships.ravel(), debias_scores.ravel())
+        self.best_threshold = thresholds[np.argmax(tpr_list - fpr_list)]
+        self.tpr = np.max(tpr_list)
+        self.fpr = np.min(fpr_list)
+
+        self.logger.info(f"Best threshold = {self.best_threshold} (Maximize TPR - FPR) = {self.tpr} - {self.fpr}")
+
+        # Apply threshold to target model scores
+        preds = mia_scores > self.best_threshold
+
+        true_tpr = np.sum(preds * target_memberships) / np.sum(target_memberships)
+        true_fpr = np.sum(preds * ~target_memberships) / np.sum(~target_memberships)
+        true_proportion = np.mean(target_memberships)
+        self.logger.info(f"True proportion {true_proportion}, True TPR: {true_tpr}, True FPR: {true_fpr}")
+
+        # Compute debiased predictions
+        debiased_pres = (preds - self.fpr)/(self.tpr - self.fpr)
+        self.logger.info(f"DUCI prediction: {np.mean(debiased_pres)}; Direct Aggregation: {np.mean(preds)}")
+
+        return debiased_pres, true_proportion
+
+    def pred_proportions(
         self, 
-        target_model_indices,
-        all_signals,
-        all_memberships,
-        num_reference_models,
-        logger,
-        configs,
-    ):
+        target_model_indices: List[int],
+        reference_model_indices_all: List[np.ndarray],
+        all_signals: np.ndarray,
+        all_memberships: np.ndarray,
+    ) -> Tuple[List[float], List[float], List[float]]:
         """
-        Launch Membership Inference Attacks for each samples in the target dataset on target models using Privacy Meter tool.
+        Launch Membership Inference Attacks on target dataset over ALL target models using Privacy Meter tool.
 
         Args:
             target_model_indices (list): List of the target model indices.
-            all_signals (np.array): Signal value of all samples in all models (target and reference models).
-            all_memberships (np.array): Membership matrix for all models.
-            num_reference_models (int): Number of reference models used for performing the attack.
-            logger (logging.Logger): Logger object for the current run.
-            configs (dict): Configs provided by the user.
-
+            reference_model_indices (list): List of the reference model indices array.
+            all_signals (np.ndarray): Softmax value of all samples in all models (target and reference models). Shape: (num_samples * num_models)
+            all_memberships (np.ndarray): Membership matrix for all models. Shape: (num_samples * num_models)
+        
         Returns:
-            list: List of MIA score arrays for all audited target models.
-            list: List of membership labels for all target models.
+            Tuple[List[float], List[float], List[float]]: A tuple containing debiased predictions, true proportions, and errors.
         """
-        all_memberships = np.transpose(all_memberships)
+        assert all_signals.shape == all_memberships.shape, f"all_signals or all_memberships has incorrect shape (num_samples * num_models): {all_signals.shape} vs {all_memberships.shape}"
 
-        mia_score_list = []
-        membership_list = []
-
-        for target_model_idx in target_model_indices:
-            baseline_time = time.time()
-            # TODO: call the MIA module
-            if configs["audit"]["algorithm"] == "RMIA":
-                offline_a = tune_offline_a(
-                    target_model_idx, all_signals, all_memberships, logger
-                )
-                logger.info(f"The best offline_a is %0.1f", offline_a)
-                mia_scores = run_rmia(
-                    target_model_idx,
-                    all_signals,
-                    all_memberships,
-                    num_reference_models,
-                    offline_a,
-                )
-            #TODO: remove the loss
-            elif configs["audit"]["algorithm"] == "LOSS":
-                mia_scores = run_loss(all_signals[:, target_model_idx])
-            else:
-                raise NotImplementedError(
-                    f"{configs['audit']['algorithm']} is not implemented"
-                )
-
-            target_memberships = all_memberships[:, target_model_idx]
-
-            mia_score_list.append(mia_scores.copy())
-            membership_list.append(target_memberships.copy())
-
-            logger.info(
-                "Collect membership prediction for target dataset on target model %d costs %0.1f seconds",
+        debiased_preds_list, true_proportion_list = [], []
+        error_list = []
+        # for target_model_idx in target_model_indices:
+        for target_model_idx, reference_model_indices in zip(target_model_indices, reference_model_indices_all):
+            debiased_pres, true_proportion = self.debias_pred(
                 target_model_idx,
-                time.time() - baseline_time,
+                reference_model_indices,
+                all_signals,
+                all_memberships,
             )
-        return mia_score_list, membership_list, offline_a
+
+            post_debias_error = np.abs(np.mean(debiased_pres) - true_proportion)
+            self.logger.info(
+                r"Absolute Error $| \hat{p} - p|$: Debiased Agg MIA = %.4f",
+                post_debias_error
+            )
+
+            debiased_preds_list.append(debiased_pres)
+            true_proportion_list.append(true_proportion)
+            error_list.append(post_debias_error)
+
+        return debiased_preds_list, true_proportion_list, error_list
+    
+    def eval():
+        pass

--- a/module_duci.py
+++ b/module_duci.py
@@ -1,0 +1,180 @@
+import numpy as np
+from sklearn.metrics import roc_curve
+import logging
+from attacks import tune_offline_a, run_rmia, run_loss
+import time
+
+logger = logging.getLogger(__name__)
+
+class DUCI:
+    def __init__(self, num_reference_models):
+        """
+        Initialize the DUCI object.
+
+        Args:
+            num_reference_models (int): Number of reference models to use.
+            offline_a (float): The offline adjustment parameter.
+        """
+        self.num_reference_models = num_reference_models
+        self.offline_a = None
+        self.best_threshold = None
+        self.tpr = None
+        self.fpr = None
+
+    def pred_proportion(self, target_model_indices, mia_score_list, membership_list, offline_a):
+        """
+        This functions takes in the MIA signals of the target dataset on the target model, 
+        the MIA signals and membership flags over the dataset of reference models to 
+        debias the MIA signals received on the target model. Then, by aggregating the
+        debiased signals, we can make an unbiased prediction to the proportion of dataset 
+        being used in the target model.
+
+        The proportion (\hat{p}) is computed as the aggregation of individual estimates (\hat{p}_i) 
+        over all data points in the target dataset (X):
+        
+            \hat{p} = (1 / |X|) * sum_{i=1}^{|X|}(\hat{p}_i)
+
+        Each individual estimate (\hat{p}_i) is calculated as:
+
+            \hat{p}_i = (\hat{m}_i - P(\hat{m}_i = 1 | m_i = 0)) / 
+                        (P(\hat{m}_i = 1 | m_i = 1) - P(\hat{m}_i = 1 | m_i = 0))
+        
+        where:
+            - \hat{m}_i: MIA signal for the i-th data point in the target dataset.
+            - P(\hat{m}_i = 1 | m_i = 0): False positive rate (FPR) derived from reference models.
+            - P(\hat{m}_i = 1 | m_i = 1): True positive rate (TPR) derived from reference models.
+            
+
+        Args:
+            target_model_idx (int): Index of the target model.
+            mia_score_list (np.ndarray): List of signal matrix with shape (samples, models).
+            membership_list (np.ndarray): List of membership matrix with shape (samples, models).
+
+        Returns:
+            dict: A dictionary containing debiased predictions, TPR, FPR, and absolute errors.
+        """
+        self.offline_a = offline_a
+        pre_debias_errors, post_debias_errors = [], []
+        for idx, target_model_idx in enumerate(target_model_indices):
+            all_signals = mia_score_list[idx]
+            all_memberships = membership_list[idx]
+            # Identify paired model and reference indices
+            paired_model_idx = target_model_idx + 1 if target_model_idx % 2 == 0 else target_model_idx - 1
+            columns = [
+                i for i in range(all_signals.shape[1])
+                if i != target_model_idx and i != paired_model_idx
+            ][:2 * self.num_reference_models]
+
+            # Select and process reference signals
+            selected_signals = all_signals[:, columns]
+            non_members = ~all_memberships[:, columns]
+            out_signals = selected_signals * non_members
+            out_signals = -np.sort(-out_signals, axis=1)[:, :self.num_reference_models]
+
+            # Compute mean values
+            mean_out_x = np.mean(out_signals, axis=1)
+            mean_x = (1 + self.offline_a) / 2 * mean_out_x + (1 - self.offline_a) / 2
+
+            # De-bias using paired model
+            ref_target_signals = all_signals[:, paired_model_idx]
+            mia_scores_for_debiasing = ref_target_signals / mean_x
+
+            debias_scores = np.array(mia_scores_for_debiasing)
+            debias_memberships = all_memberships[:, paired_model_idx]
+
+            # Find the optimal threshold
+            fpr_list, tpr_list, thresholds = roc_curve(debias_memberships.ravel(), debias_scores.ravel())
+            self.best_threshold = thresholds[np.argmax(tpr_list - fpr_list)]
+            self.tpr = np.max(tpr_list)
+            self.fpr = np.min(fpr_list)
+
+            logger.info(f"Best threshold = {self.best_threshold} (Maximize TPR - FPR) = {self.tpr} - {self.fpr}")
+
+            # Apply threshold to target model scores
+            preds = (all_signals[:, target_model_idx] > self.best_threshold).ravel()
+            target_memberships = all_memberships[:, target_model_idx]
+
+            true_tpr = np.sum(preds * target_memberships.ravel()) / np.sum(target_memberships.ravel())
+            true_fpr = np.sum(preds * ~target_memberships.ravel()) / np.sum(~target_memberships.ravel())
+
+            logger.info(f"Direct aggregation of MIA preds: {np.mean(preds)}, TPR: {true_tpr}, FPR: {true_fpr}")
+
+            # Compute debiased predictions
+            debiased_pres = (preds - self.fpr)/(self.tpr - self.fpr)
+            true_proportion = np.mean(target_memberships)
+            logger.info(f"Debiased aggregation of MIA preds: {np.mean(debiased_pres)}")
+            pre_debias_error = np.abs(np.mean(preds) - true_proportion)
+            post_debias_error = np.abs(np.mean(debiased_pres) - true_proportion)
+            logger.info(
+                r"Absolute Error $| \hat{p} - p|$: Agg MIA = %.4f, Debiased Agg MIA = %.4f",
+                pre_debias_error,
+                post_debias_error
+            )
+            pre_debias_errors.append(pre_debias_error)
+            post_debias_errors.append(post_debias_error)
+
+        return pre_debias_errors, post_debias_errors
+    
+    def get_ind_signals(
+        self, 
+        target_model_indices,
+        all_signals,
+        all_memberships,
+        num_reference_models,
+        logger,
+        configs,
+    ):
+        """
+        Launch Membership Inference Attacks for each samples in the target dataset on target models using Privacy Meter tool.
+
+        Args:
+            target_model_indices (list): List of the target model indices.
+            all_signals (np.array): Signal value of all samples in all models (target and reference models).
+            all_memberships (np.array): Membership matrix for all models.
+            num_reference_models (int): Number of reference models used for performing the attack.
+            logger (logging.Logger): Logger object for the current run.
+            configs (dict): Configs provided by the user.
+
+        Returns:
+            list: List of MIA score arrays for all audited target models.
+            list: List of membership labels for all target models.
+        """
+        all_memberships = np.transpose(all_memberships)
+
+        mia_score_list = []
+        membership_list = []
+
+        for target_model_idx in target_model_indices:
+            baseline_time = time.time()
+            # TODO: call the MIA module
+            if configs["audit"]["algorithm"] == "RMIA":
+                offline_a = tune_offline_a(
+                    target_model_idx, all_signals, all_memberships, logger
+                )
+                logger.info(f"The best offline_a is %0.1f", offline_a)
+                mia_scores = run_rmia(
+                    target_model_idx,
+                    all_signals,
+                    all_memberships,
+                    num_reference_models,
+                    offline_a,
+                )
+            #TODO: remove the loss
+            elif configs["audit"]["algorithm"] == "LOSS":
+                mia_scores = run_loss(all_signals[:, target_model_idx])
+            else:
+                raise NotImplementedError(
+                    f"{configs['audit']['algorithm']} is not implemented"
+                )
+
+            target_memberships = all_memberships[:, target_model_idx]
+
+            mia_score_list.append(mia_scores.copy())
+            membership_list.append(target_memberships.copy())
+
+            logger.info(
+                "Collect membership prediction for target dataset on target model %d costs %0.1f seconds",
+                target_model_idx,
+                time.time() - baseline_time,
+            )
+        return mia_score_list, membership_list, offline_a

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,1 +1,0 @@
-from .mia import run_mia as mia

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,1 @@
+from .mia import run_mia as mia

--- a/modules/mia/__init__.py
+++ b/modules/mia/__init__.py
@@ -1,1 +1,1 @@
-from .attack import run_mia
+from .attack import MIA

--- a/modules/mia/__init__.py
+++ b/modules/mia/__init__.py
@@ -1,0 +1,1 @@
+from .attack import run_mia

--- a/modules/mia/attack.py
+++ b/modules/mia/attack.py
@@ -1,48 +1,85 @@
-from typing import Any, Tuple, Dict
+from typing import Any, Tuple, Dict, Optional
 import logging
 import numpy as np
 from .attacks import run_rmia, tune_offline_a
 
-def run_mia(
-    all_signals: np.ndarray,
-    all_memberships: np.ndarray,
-    target_model_idx: int,
-    reference_model_indices: np.ndarray,
-    logger: logging.Logger,
-    args: Dict[str, Any],
-) -> Tuple[np.ndarray, np.ndarray]:
-    """
-    Launch a membership inference attack on a target model and output the MIA scores.
-    
-    Args:
-        all_signals (np.ndarray): Softmax value of all samples in all models (target and reference models). Shape: (num_samples * num_models)
-        all_memberships (np.ndarray): Membership matrix for all models. Shape: (num_samples * num_models)
-        target_model_idx (int): Index of the target model.
-        reference_model_indices (np.ndarray): List of indices of reference models.
-        args (Dict[str, Any]): Arguments for the MIA attack.
+class MIA:
+    def __init__(self, logger: logging.Logger):
+        """
+        Initialize the MIA object with configuration storage and a logger.
 
-    Returns:
-        Tuple[np.ndarray, np.ndarray]: MIA scores for all samples in the target model and the membership labels for the target model.
-    """
-    assert all_signals.shape == all_memberships.shape, f"all_signals or all_memberships has incorrect shape (num_samples * num_models): {all_signals.shape} vs {all_memberships.shape}"
-    target_signals = all_signals[:, target_model_idx]
-    target_memberships = all_memberships[:, target_model_idx]
-
-    ref_signals = all_signals[:, reference_model_indices]
-    ref_memberships = all_memberships[:, reference_model_indices]
+        Args:
+            args (Dict[str, Any]): Configuration storage for existing MIA attacks to avoid retuning.
+            logger (logging.Logger): Logger instance for logging information.
+        """
+        self.configs: Dict[frozenset, Dict[str, Any]] = {}
+        self.logger = logger
     
-    logger.info(f"Args for MIA attack: {args}")
-    if args["attack"] == "RMIA":
-        if args.get("offline_a") is None:
-            offline_a, _, _ = tune_offline_a(target_model_idx, all_signals, all_memberships, ref_signals, ref_memberships, logger)
-            # offline_a = args.get("offline_a", 0.3)
+    def _serialize_args(self, args: Dict[str, Any]) -> frozenset:
+        """
+        Serialize the args dictionary into a frozenset to use as a hashable key.
+
+        Args:
+            args (Dict[str, Any]): The configuration arguments.
+
+        Returns:
+            frozenset: A hashable representation of the args.
+        """
+        keys_to_extract = ["attack", "dataset", "model"]  # Keys to include in the frozenset
+        extracted_items = [(key, args[key]) for key in keys_to_extract if key in args]
+        return frozenset(extracted_items)
+    
+    def run_mia(
+        self,
+        all_signals: np.ndarray,
+        all_memberships: np.ndarray,
+        target_model_idx: int,
+        reference_model_indices: np.ndarray,
+        logger: logging.Logger,
+        args: Dict[str, Any],
+        reuse_offline_a: Optional[bool] = False,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Launch a membership inference attack on a target model and output the MIA scores.
         
-        logger.info(f"Running RMIA attack on target model {target_model_idx} with offline_a={offline_a}")
-        mia_scores = run_rmia(target_signals, ref_signals, ref_memberships, offline_a)
-    else:
-        raise ValueError(f"Attack type {args['attack']} is not supported. Please load your own attack scores.")  
-    
-    return mia_scores, target_memberships
+        Args:
+            all_signals (np.ndarray): Softmax value of all samples in all models (target and reference models). Shape: (num_samples * num_models)
+            all_memberships (np.ndarray): Membership matrix for all models. Shape: (num_samples * num_models)
+            target_model_idx (int): Index of the target model.
+            reference_model_indices (np.ndarray): List of indices of reference models.
+            args (Dict[str, Any]): Arguments for the MIA attack.
+
+        Returns:
+            Tuple[np.ndarray, np.ndarray]: MIA scores for all samples in the target model and the membership labels for the target model.
+        """
+        assert all_signals.shape == all_memberships.shape, f"all_signals or all_memberships has incorrect shape (num_samples * num_models): {all_signals.shape} vs {all_memberships.shape}"
+        target_signals = all_signals[:, target_model_idx]
+        target_memberships = all_memberships[:, target_model_idx]
+
+        ref_signals = all_signals[:, reference_model_indices]
+        ref_memberships = all_memberships[:, reference_model_indices]
+        
+        logger.info(f"Args for MIA attack: {args}")
+        if args["attack"] == "RMIA":
+            if args.get("offline_a") is None:
+                serialized_key = self._serialize_args(args)
+                # Reuse the offline_a if it has been computed before for the same dataset and architecture
+                if reuse_offline_a and serialized_key in self.configs:
+                    offline_a = self.configs[serialized_key]["offline_a"]
+                    logger.info(f"Using cached offline_a={offline_a}")
+                else:
+                    offline_a, _, _ = tune_offline_a(target_model_idx, all_signals, all_memberships, ref_signals, ref_memberships, logger)
+                    # offline_a = args.get("offline_a", 0.3)
+                    args["offline_a"] = offline_a
+                    self.configs[serialized_key] = args
+            else:
+                offline_a = args["offline_a"]
+            logger.info(f"Running RMIA attack on target model {target_model_idx} with offline_a={offline_a}")
+            mia_scores = run_rmia(target_signals, ref_signals, ref_memberships, offline_a)
+        else:
+            raise ValueError(f"Attack type {args['attack']} is not supported. Please load your own attack scores.")  
+        
+        return mia_scores, target_memberships
 
   
 

--- a/modules/mia/attack.py
+++ b/modules/mia/attack.py
@@ -1,0 +1,52 @@
+from typing import Any, Tuple, Dict
+import logging
+import numpy as np
+from .attacks import run_rmia, tune_offline_a
+
+def run_mia(
+    all_signals: np.ndarray,
+    all_memberships: np.ndarray,
+    target_model_idx: int,
+    reference_model_indices: np.ndarray,
+    logger: logging.Logger,
+    args: Dict[str, Any],
+) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Launch a membership inference attack on a target model and output the MIA scores.
+    
+    Args:
+        all_signals (np.ndarray): Softmax value of all samples in all models (target and reference models). Shape: (num_samples * num_models)
+        all_memberships (np.ndarray): Membership matrix for all models. Shape: (num_samples * num_models)
+        target_model_idx (int): Index of the target model.
+        reference_model_indices (np.ndarray): List of indices of reference models.
+        args (Dict[str, Any]): Arguments for the MIA attack.
+
+    Returns:
+        Tuple[np.ndarray, np.ndarray]: MIA scores for all samples in the target model and the membership labels for the target model.
+    """
+    assert all_signals.shape == all_memberships.shape, f"all_signals or all_memberships has incorrect shape (num_samples * num_models): {all_signals.shape} vs {all_memberships.shape}"
+    target_signals = all_signals[:, target_model_idx]
+    target_memberships = all_memberships[:, target_model_idx]
+
+    ref_signals = all_signals[:, reference_model_indices]
+    ref_memberships = all_memberships[:, reference_model_indices]
+    
+    logger.info(f"Args for MIA attack: {args}")
+    if args["attack"] == "RMIA":
+        if args.get("offline_a") is None:
+            offline_a, _, _ = tune_offline_a(target_model_idx, all_signals, all_memberships, ref_signals, ref_memberships, logger)
+            # offline_a = args.get("offline_a", 0.3)
+        
+        logger.info(f"Running RMIA attack on target model {target_model_idx} with offline_a={offline_a}")
+        mia_scores = run_rmia(target_signals, ref_signals, ref_memberships, offline_a)
+    else:
+        raise ValueError(f"Attack type {args['attack']} is not supported. Please load your own attack scores.")  
+    
+    return mia_scores, target_memberships
+
+  
+
+
+
+
+

--- a/modules/mia/attacks/__init__.py
+++ b/modules/mia/attacks/__init__.py
@@ -1,0 +1,1 @@
+from .rmia import run_rmia, tune_offline_a

--- a/modules/mia/attacks/loss.py
+++ b/modules/mia/attacks/loss.py
@@ -1,0 +1,14 @@
+# import numpy as np
+
+# def run_loss(target_signals: np.ndarray) -> np.ndarray:
+#     """
+#     Attack a target model using the LOSS attack.
+
+#     Args:
+#         target_signals (np.ndarray): Softmax value of all samples in the target model.
+
+#     Returns:
+#         np.ndarray: MIA score for all samples (a larger score indicates higher chance of being member).
+#     """
+#     mia_scores = -target_signals
+#     return mia_scores

--- a/modules/mia/attacks/rmia.py
+++ b/modules/mia/attacks/rmia.py
@@ -1,0 +1,208 @@
+from typing import Any, Optional
+from sklearn.metrics import auc, roc_curve
+import numpy as np
+
+# def get_rmia_out_signals(
+#     all_signals: np.ndarray,
+#     all_memberships: np.ndarray,
+#     target_model_idx: int,
+#     num_reference_models: int,
+# ) -> np.ndarray:
+#     """
+#     Get average prediction probability of samples over offline reference models (excluding the target model).
+
+#     Args:
+#         all_signals (np.ndarray): Softmax value of all samples in every model.
+#         all_memberships (np.ndarray): Membership matrix for all models (if a sample is used for training a model).
+#         target_model_idx (int): Target model index.
+#         num_reference_models (int): Number of reference models used for the attack.
+
+#     Returns:
+#         np.ndarray: Average softmax value for each sample over OUT reference models.
+#     """
+#     paired_model_idx = (
+#         target_model_idx + 1 if target_model_idx % 2 == 0 else target_model_idx - 1
+#     )
+#     # Add non-target and non-paired model indices
+#     columns = [
+#         i
+#         for i in range(all_signals.shape[1])
+#         if i != target_model_idx and i != paired_model_idx
+#     ][: 2 * num_reference_models]
+#     selected_signals = all_signals[:, columns]
+#     non_members = ~all_memberships[:, columns]
+#     out_signals = selected_signals * non_members
+#     # Sort the signals such that only the non-zero signals (out signals) are kept
+#     out_signals = -np.sort(-out_signals, axis=1)[:, :num_reference_models]
+#     return out_signals
+
+
+# def tune_offline_a(
+#     target_model_idx: int,
+#     all_signals: np.ndarray,
+#     all_memberships: np.ndarray,
+#     logger: Any,
+# ) -> float:
+#     """
+#     Fine-tune coefficient offline_a used in RMIA.
+
+#     Args:
+#         target_model_idx (int): Index of the target model.
+#         all_signals (np.ndarray): Softmax value of all samples in two models (target and reference).
+#         all_memberships (np.ndarray): Membership matrix for all models.
+#         logger (Any): Logger object for the current run.
+
+#     Returns:
+#         float: Optimized offline_a obtained by attacking a paired model with the help of the reference models.
+#     """
+#     paired_model_idx = (
+#         target_model_idx + 1 if target_model_idx % 2 == 0 else target_model_idx - 1
+#     )
+#     logger.info(f"Fine-tuning offline_a using paired model {paired_model_idx}")
+#     paired_memberships = all_memberships[:, paired_model_idx]
+#     offline_a = 0.0
+#     max_auc = 0
+#     for test_a in np.arange(0, 1.1, 0.1):
+#         mia_scores = run_rmia(paired_model_idx, all_signals, all_memberships, 1, test_a)
+#         fpr_list, tpr_list, _ = roc_curve(
+#             paired_memberships.ravel(), mia_scores.ravel()
+#         )
+#         roc_auc = auc(fpr_list, tpr_list)
+#         if roc_auc > max_auc:
+#             max_auc = roc_auc
+#             offline_a = test_a
+#             mia_scores_array = mia_scores.ravel().copy()
+#             membership_array = paired_memberships.ravel().copy()
+#         logger.info(f"offline_a={test_a:.2f}: AUC {roc_auc:.4f}")
+#     return offline_a, mia_scores_array, membership_array
+
+
+# def run_rmia(
+#     target_model_idx: int,
+#     all_signals: np.ndarray,
+#     all_memberships: np.ndarray,
+#     num_reference_models: int,
+#     offline_a: float,
+# ) -> np.ndarray:
+#     """
+#     Attack a target model using the RMIA attack with the help of offline reference models.
+
+#     Args:
+#         target_model_idx (int): Index of the target model.
+#         all_signals (np.ndarray): Softmax value of all samples in the target model.
+#         all_memberships (np.ndarray): Membership matrix for all models.
+#         num_reference_models (int): Number of reference models used for the attack.
+#         offline_a (float): Coefficient offline_a is used to approximate p(x) using P_out in the offline setting.
+
+#     Returns:
+#         np.ndarray: MIA score for all samples (a larger score indicates higher chance of being member).
+#     """
+#     target_signals = all_signals[:, target_model_idx]
+#     out_signals = get_rmia_out_signals(
+#         all_signals, all_memberships, target_model_idx, num_reference_models
+#     )
+#     mean_out_x = np.mean(out_signals, axis=1)
+#     mean_x = (1 + offline_a) / 2 * mean_out_x + (1 - offline_a) / 2
+#     prob_ratio_x = target_signals.ravel() / mean_x
+
+#     return prob_ratio_x
+
+def get_out_ref_signals(
+    ref_signals: np.ndarray,
+    ref_memberships: np.ndarray,
+    num_reference_models: Optional[int] = None,
+) -> np.ndarray:
+    """
+    Get average prediction probability of samples over offline reference models (excluding the target model).
+
+    Args:
+        ref_signals (np.ndarray): Softmax value of all samples in all reference model.  Shape: (num_samples * num_models)
+        ref_memberships (np.ndarray): Membership matrix for all reference models (if a sample is used for training a model).  Shape: (num_samples * num_models)
+        num_reference_models (Optional[int]): Number of reference models used for the attack. Defaults to half reference models if None.
+
+    Returns:
+        np.ndarray: Average softmax value for each sample over OUT reference models.
+    """
+    non_members = ~ref_memberships
+    out_signals = ref_signals * non_members
+    # Sort the signals such that only the non-zero signals (out signals) for each sample are kept
+    if num_reference_models is None:
+        num_reference_models = ref_signals.shape[1]
+    out_signals = -np.sort(-out_signals, axis=1)[:, :num_reference_models]
+    return out_signals
+
+def tune_offline_a(
+    target_model_idx: int,
+    all_signals: np.ndarray,
+    all_memberships: np.ndarray,
+    ref_signals: np.ndarray,
+    ref_memberships: np.ndarray,
+    logger: Any,
+) -> float:
+    """
+    Fine-tune coefficient offline_a used in RMIA.
+
+    Args:
+        target_model_idx (int): Index of the target model.
+        all_signals (np.ndarray): Softmax value of all samples in two models (target and reference).
+        all_memberships (np.ndarray): Membership matrix for all models.
+        ref_signals (np.ndarray): Softmax value of all samples in all reference models.
+        ref_memberships (np.ndarray): Membership matrix for all reference models.
+        logger (Any): Logger object for the current run.
+
+    Returns:
+        float: Optimized offline_a obtained by attacking a paired model with the help of the reference models.
+    """
+    paired_model_idx = (
+        target_model_idx + 1 if target_model_idx % 2 == 0 else target_model_idx - 1
+    )
+    logger.info(f"Fine-tuning offline_a using paired model {paired_model_idx}")
+    paired_memberships = all_memberships[:, paired_model_idx]
+    offline_a = 0.0
+    max_auc = 0
+    for test_a in np.arange(0, 1.1, 0.1):
+        paired_signals = all_signals[:, paired_model_idx]
+
+        # launch RMIA using one pair of reference models on the paired model
+        mia_scores = run_rmia(paired_signals, ref_signals, ref_memberships, test_a, 1)
+
+        fpr_list, tpr_list, _ = roc_curve(
+            paired_memberships.ravel(), mia_scores.ravel()
+        )
+        roc_auc = auc(fpr_list, tpr_list)
+        if roc_auc > max_auc:
+            max_auc = roc_auc
+            offline_a = test_a
+            mia_scores_array = mia_scores.ravel().copy()
+            membership_array = paired_memberships.ravel().copy()
+        logger.info(f"offline_a={test_a:.2f}: AUC {roc_auc:.4f}")
+    return offline_a, mia_scores_array, membership_array
+
+def run_rmia(
+    target_signals: np.ndarray,
+    ref_signals: np.ndarray,
+    ref_memberships: np.ndarray,
+    offline_a: float,
+    num_reference_models: Optional[int] = None,
+) -> np.ndarray:
+    """
+    Attack a target model using the RMIA attack with the help of offline reference models.
+
+    Args:
+        target_signals (np.ndarray): Softmax value of all samples in the target model.
+        ref_signals (np.ndarray): Softmax value of all samples in the reference models.
+        ref_memberships (np.ndarray): Membership matrix for all reference models.
+        offline_a (float): Coefficient offline_a is used to approximate p(x) using P_out in the offline setting.
+        num_reference_models (Optional[int]): Number of reference models used for the attack. Defaults to half reference models if None.
+    
+    Returns:
+        np.ndarray: MIA score for all samples (a larger score indicates higher chance of being member).
+    """
+    if num_reference_models is None:
+        num_reference_models = ref_signals.shape[1]//2
+    out_signals = get_out_ref_signals(ref_signals, ref_memberships, num_reference_models)
+    mean_out_x = np.mean(out_signals, axis=1)
+    mean_x = (1 + offline_a) / 2 * mean_out_x + (1 - offline_a) / 2
+    prob_ratio_x = target_signals.ravel() / mean_x
+
+    return prob_ratio_x

--- a/ramia_scores.py
+++ b/ramia_scores.py
@@ -5,12 +5,15 @@ def get_topk(array, k):
     id = (-array).argsort(axis=1)[:, :k]
     return array[np.arange(array.shape[0])[:, None], id]
 
+
 def get_bottomk(array, k):
     id = array.argsort(axis=1)[:, :k]
     return array[np.arange(array.shape[0])[:, None], id]
 
 
-def trim_mia_scores(mia_scores: np.ndarray, trim_ratio: float, trim_direction: str) -> np.ndarray:
+def trim_mia_scores(
+    mia_scores: np.ndarray, trim_ratio: float, trim_direction: str
+) -> np.ndarray:
     """
     Trim the MIA scores to remove the samples that are not members.
 
@@ -29,7 +32,11 @@ def trim_mia_scores(mia_scores: np.ndarray, trim_ratio: float, trim_direction: s
         return mia_scores.mean(axis=1)
 
     if trim_direction == "top":
-        return get_bottomk(mia_scores, int(trim_ratio * mia_scores.shape[1])).mean(axis=1)
+        return get_bottomk(
+            mia_scores, int((1 - trim_ratio) * mia_scores.shape[1])
+        ).mean(axis=1)
 
     if trim_direction == "bottom":
-        return get_topk(mia_scores, int(trim_ratio * mia_scores.shape[1])).mean(axis=1)
+        return get_topk(mia_scores, int((1 - trim_ratio) * mia_scores.shape[1])).mean(
+            axis=1
+        )

--- a/ramia_scores.py
+++ b/ramia_scores.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+
+def get_topk(array, k):
+    id = (-array).argsort(axis=1)[:, :k]
+    return array[np.arange(array.shape[0])[:, None], id]
+
+def get_bottomk(array, k):
+    id = array.argsort(axis=1)[:, :k]
+    return array[np.arange(array.shape[0])[:, None], id]
+
+
+def trim_mia_scores(mia_scores: np.ndarray, trim_ratio: float, trim_direction: str) -> np.ndarray:
+    """
+    Trim the MIA scores to remove the samples that are not members.
+
+    Args:
+        mia_scores (np.ndarray): The MIA scores.
+        trim_ratio (float): The ratio of samples to trim.
+        trim_direction (str): The direction to trim the samples. Can be "none", "top", or "bottom".
+
+    Returns:
+        np.ndarray: The trimmed MIA score means.
+    """
+    if trim_direction not in ["none", "top", "bottom"]:
+        raise ValueError(f"Invalid trim_direction: {trim_direction}")
+
+    if trim_direction == "none":
+        return mia_scores.mean(axis=1)
+
+    if trim_direction == "top":
+        return get_bottomk(mia_scores, int(trim_ratio * mia_scores.shape[1])).mean(axis=1)
+
+    if trim_direction == "bottom":
+        return get_topk(mia_scores, int(trim_ratio * mia_scores.shape[1])).mean(axis=1)

--- a/range_samplers/__init__.py
+++ b/range_samplers/__init__.py
@@ -1,0 +1,3 @@
+from .sample_l2 import sample_l2
+from .sample_geometric import sample_geometric
+from .sample_word_replace import sample_word_replace

--- a/range_samplers/sample_geometric.py
+++ b/range_samplers/sample_geometric.py
@@ -22,7 +22,7 @@ def sample_geometric(range_center, transformations_list, sample_size):
         sample_size (int): The number of samples to generate.
 
     Returns:
-        np.ndarray: The samples in the geometric range.
+        list[torch.tensors]: The samples in the geometric range.
     """
     # Initialize the samples list
     if len(transformations_list) == sample_size - 1:
@@ -37,7 +37,7 @@ def sample_geometric(range_center, transformations_list, sample_size):
         else:
             raise ValueError(f"Invalid transformation: {transformation}")
 
-    return np.array(samples)
+    return samples
 
 
 # Test

--- a/range_samplers/sample_geometric.py
+++ b/range_samplers/sample_geometric.py
@@ -1,0 +1,54 @@
+import pdb
+
+import numpy as np
+import torchvision.transforms as T
+import pickle
+
+# Define a mapping from string names to torchvision augmentation functions
+augmentation_mapping = {
+    "horizontal_flip": T.RandomHorizontalFlip(p=1.0),
+    "vertical_flip": T.RandomVerticalFlip(p=1.0),
+    "rotate": T.RandomRotation(degrees=30),
+}
+
+
+def sample_geometric(range_center, transformations_list, sample_size):
+    """
+    Sample points in the geometric range of the range_center.
+
+    Args:
+        range_center (np.ndarray): The center of the range.
+        transformations_list (list): A list of strings representing the transformations to apply.
+        sample_size (int): The number of samples to generate.
+
+    Returns:
+        np.ndarray: The samples in the geometric range.
+    """
+    # Initialize the samples list
+    if len(transformations_list) == sample_size - 1:
+        samples = [range_center] # Include the range_center as the first sample
+    else:
+        samples = []
+
+    # Apply each transformation to the range_center
+    for transformation in transformations_list:
+        if transformation in augmentation_mapping:
+            samples.append(augmentation_mapping[transformation](range_center))
+        else:
+            raise ValueError(f"Invalid transformation: {transformation}")
+
+    return np.array(samples)
+
+
+# Test
+# with open("data/cifar10.pkl", "rb") as f:
+#     dataset = pickle.load(f)
+# first_image, _ = dataset[0] # First image and label
+# print("Original Image Size:", first_image.shape)
+#
+# # Transformations to test
+# transformations_list = ["horizontal_flip", "vertical_flip", "rotate"]
+#
+# # Generate augmented samples
+# samples = sample_geometric(first_image, transformations_list, sample_size=3)
+# print("Augmented Samples Size:", samples.shape)

--- a/range_samplers/sample_l2.py
+++ b/range_samplers/sample_l2.py
@@ -1,3 +1,5 @@
+import pdb
+
 import numpy as np
 import torch
 
@@ -11,13 +13,12 @@ def sample_l2(range_center, radius, sample_size):
         radius (float): The radius of the L2 ball.
         sample_size (int): The number of points to sample.
     Returns:
-        np.ndarray: Points sampled within the L2 ball.
+        list: Points sampled within the L2 ball.
     """
     if type(range_center) == torch.Tensor:
         range_center = range_center.numpy()
 
     sampled_points = []
-
     if range_center.shape[0] == 1:
         range_center = range_center.squeeze(0)
 
@@ -29,9 +30,9 @@ def sample_l2(range_center, radius, sample_size):
         candidate = np.random.normal(loc=range_center, scale=scale, size=range_center.shape)
         # Check if the candidate point lies within the L2 ball
         if np.linalg.norm(candidate - range_center) <= radius:
-            sampled_points.append(candidate)
+            sampled_points.append(torch.tensor(candidate, dtype=torch.float32))
 
-    return np.array(sampled_points)
+    return sampled_points
 
 # Test
 # range_center = np.random.rand(1, 28,28,3)# Center of the 3D ball

--- a/range_samplers/sample_l2.py
+++ b/range_samplers/sample_l2.py
@@ -1,0 +1,49 @@
+import numpy as np
+import torch
+
+
+def sample_l2(range_center, radius, sample_size):
+    """
+    Sample points within the L2 range using Gaussian sampling with a scale
+    dynamically adjusted for the sample size.
+    Args:
+        range_center (np.ndarray): The center of the L2 ball (N-dimensional point).
+        radius (float): The radius of the L2 ball.
+        sample_size (int): The number of points to sample.
+    Returns:
+        np.ndarray: Points sampled within the L2 ball.
+    """
+    if type(range_center) == torch.Tensor:
+        range_center = range_center.numpy()
+
+    sampled_points = []
+
+    if range_center.shape[0] == 1:
+        range_center = range_center.squeeze(0)
+
+    # Adjust scale based on radius and data size
+    scale = radius / np.sqrt(len(range_center.reshape(-1)))
+
+    while len(sampled_points) < sample_size:
+        # Sample a candidate point from a multivariate normal distribution
+        candidate = np.random.normal(loc=range_center, scale=scale, size=range_center.shape)
+        # Check if the candidate point lies within the L2 ball
+        if np.linalg.norm(candidate - range_center) <= radius:
+            sampled_points.append(candidate)
+
+    return np.array(sampled_points)
+
+# Test
+# range_center = np.random.rand(1, 28,28,3)# Center of the 3D ball
+# print(range_center.shape)
+# radius = 3.0  # L2 radius
+# sample_size = 10  # Number of points to sample
+#
+# samples = sample_l2_gaussian(range_center, radius, sample_size)
+#
+# print("Sampled Points:\n", samples.shape)
+#
+# # Verify distances
+# distances = [np.linalg.norm(sample - range_center) for sample in samples]
+# print("Distances from center:\n", distances)
+# print("Maximum distance:", np.max(distances))  # Should be <= radius

--- a/range_samplers/sample_word_replace.py
+++ b/range_samplers/sample_word_replace.py
@@ -17,7 +17,7 @@ def sample_word_replace(range_center, mask_model, mask_tokenizer, num_masks, sam
         sample_size (int): The number of sentences to sample.
         device (str): The device to run the masked language model on.
     Returns:
-        list: Sentences sampled with word replacements.
+        list[str]: Sentences sampled with word replacements.
     """
     # Load the masked language model
     mlm_model = AutoModelForMaskedLM.from_pretrained(mask_model).to(device)

--- a/range_samplers/sample_word_replace.py
+++ b/range_samplers/sample_word_replace.py
@@ -1,0 +1,90 @@
+import torch
+import random
+from transformers import (
+    AutoModelForMaskedLM,
+    AutoTokenizer
+)
+
+
+def sample_word_replace(range_center, mask_model, mask_tokenizer, num_masks, sample_size, device):
+    """
+    Sample sentences with word replacements using a masked language model.
+    Args:
+        range_center (str): The sentence to sample around.
+        mask_model (str): The masked language model to use.
+        mask_tokenizer (str): The tokenizer for the masked language model.
+        num_masks (int): The number of words to mask in each sentence.
+        sample_size (int): The number of sentences to sample.
+        device (str): The device to run the masked language model on.
+    Returns:
+        list: Sentences sampled with word replacements.
+    """
+    # Load the masked language model
+    mlm_model = AutoModelForMaskedLM.from_pretrained(mask_model).to(device)
+    mlm_tokenizer = AutoTokenizer.from_pretrained(mask_tokenizer)
+
+    # Mask the input sentence
+    attempts = 0
+    new_sentences = [range_center]
+    words = range_center.split()
+    num_words = len(words)
+
+    if num_words <= num_masks:
+        # If there are not enough words to mask, return the original text repeated m times
+        raise ValueError("Not enough words to mask")
+
+    while len(new_sentences) < sample_size:
+        masked_words = words[:]
+        k = random.randint(1, num_masks)
+        masked_indices = random.sample(range(num_words), k)
+        original_masked_words = [
+            words[idx] for idx in masked_indices
+        ]  # Keep original words for comparison
+        for index in masked_indices:
+            masked_words[index] = "[MASK]"
+        masked_sentence = " ".join(masked_words)
+
+        # Tokenize the masked sentence
+        inputs = mlm_tokenizer(masked_sentence, return_tensors="pt").to(device)
+
+        # Get predictions
+        with torch.no_grad():
+            outputs = mlm_model(**inputs)
+            predictions = outputs.logits
+
+        # Replace '[MASK]' tokens by selecting from the top 6, excluding the original word
+        mask_token_index = (inputs.input_ids[0] == mlm_tokenizer.mask_token_id).nonzero(
+            as_tuple=True
+        )[0]
+        for i, mask_index in enumerate(mask_token_index):
+            mask_word_logits = predictions[0, mask_index]
+            top_tokens = torch.topk(mask_word_logits, 6, dim=0).indices
+            # Decode tokens to filter out the original word
+            decoded_tokens = [mlm_tokenizer.decode([tok_id]) for tok_id in top_tokens]
+            filtered_tokens = [
+                tok_id
+                for tok, tok_id in zip(decoded_tokens, top_tokens)
+                if tok != original_masked_words[i]
+            ]
+
+            if filtered_tokens:
+                # Select a random token from filtered tokens that is not the original masked word
+                selected_token = random.choice(filtered_tokens)
+                inputs.input_ids[0, mask_index] = selected_token
+            else:
+                # If all top tokens are the original word, use the top token by default
+                raise ValueError("All top tokens are the original word")
+
+        # Decode the modified sentence
+        new_sentence = mlm_tokenizer.decode(
+            inputs.input_ids.squeeze(0), skip_special_tokens=True
+        )
+
+        # Check for duplicates
+        if new_sentence != range_center and new_sentence not in new_sentences:
+            new_sentences.append(new_sentence)
+        else:
+            attempts += 1
+            if attempts >= 100:
+                raise ValueError("Could not generate enough unique sentences")
+    return new_sentences

--- a/run_duci.py
+++ b/run_duci.py
@@ -1,0 +1,144 @@
+"""This file is the main entry point for running the privacy auditing tool."""
+
+import argparse
+import math
+import time
+
+import torch
+import yaml
+import numpy as np
+
+from audit import get_average_audit_results, audit_models, sample_auditing_dataset
+from get_signals import get_model_signals
+from models.utils import load_models, train_models, split_dataset_for_training
+from util import (
+    check_configs,
+    setup_log,
+    initialize_seeds,
+    create_directories,
+    load_dataset,
+)
+from module_duci import DUCI
+
+# Enable benchmark mode in cudnn to improve performance when input sizes are consistent
+torch.backends.cudnn.benchmark = True
+
+
+def main():
+    print(20 * "-")
+    print("Run Dataset Usage Cardinality Inference!")
+    print(20 * "-")
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(description="Run DUCI using Privacy Meter.")
+    parser.add_argument(
+        "--cf",
+        type=str,
+        default="configs/cifar10.yaml",
+        help="Path to the configuration YAML file.",
+    )
+    args = parser.parse_args()
+
+    # Load configuration file
+    with open(args.cf, "rb") as f:
+        configs = yaml.load(f, Loader=yaml.Loader)
+
+    # Validate configurations
+    check_configs(configs)
+
+    # Initialize seeds for reproducibility
+    initialize_seeds(configs["run"]["random_seed"])
+
+    # Create necessary directories
+    log_dir = configs["run"]["log_dir"]
+    directories = {
+        "log_dir": log_dir,
+        "report_dir": f"{log_dir}/report",
+        "signal_dir": f"{log_dir}/signals",
+        "data_dir": configs["data"]["data_dir"],
+    }
+    create_directories(directories)
+
+    # Set up logger
+    logger = setup_log(
+        directories["report_dir"], "time_analysis", configs["run"]["time_log"]
+    )
+
+    start_time = time.time()
+
+    # Load the dataset
+    baseline_time = time.time()
+    dataset = load_dataset(configs, directories["data_dir"], logger)
+    logger.info("Loading dataset took %0.5f seconds", time.time() - baseline_time)
+
+    # Define experiment parameters
+    num_experiments = configs["run"]["num_experiments"]
+    num_reference_models = configs["audit"]["num_ref_models"]
+    num_model_pairs = max(math.ceil(num_experiments / 2.0), num_reference_models + 1)
+
+    # Load or train models
+    baseline_time = time.time()
+    models_list, memberships = load_models(
+        log_dir, dataset, num_model_pairs * 2, configs, logger
+    )
+    if models_list is None:
+        # Split dataset for training two models per pair
+        data_splits, memberships = split_dataset_for_training(
+            len(dataset), num_model_pairs
+        )
+        models_list = train_models(
+            log_dir, dataset, data_splits, memberships, configs, logger
+        )
+    logger.info(
+        "Model loading/training took %0.1f seconds", time.time() - baseline_time
+    )
+
+    auditing_dataset, auditing_membership = sample_auditing_dataset(
+        configs, dataset, logger, memberships
+    )
+
+    # Generate signals (softmax outputs) for all models
+    baseline_time = time.time()
+    signals = get_model_signals(models_list, auditing_dataset, configs, logger) # num_models * num_samples
+    logger.info("Preparing signals took %0.5f seconds", time.time() - baseline_time)
+
+    # Perform DUCI
+    baseline_time = time.time()
+    target_model_indices = list(range(num_experiments))
+
+    logger.info(f"Initiate DUCI for target models: {target_model_indices}")
+    DUCI_instance = DUCI(num_reference_models)
+
+    logger.info("Collecting membership prediction for each sample in the target dataset on target models and reference models.")
+    mia_score_list, membership_list, offline_a = DUCI_instance.get_ind_signals(
+        target_model_indices,
+        signals,
+        auditing_membership,
+        num_reference_models,
+        logger,
+        configs,
+    )
+
+    logger.info("Predicting the proportion of dataset usage on target models.") #TODO: remove the baseline
+    _, duci = DUCI_instance.pred_proportion(
+        target_model_indices, 
+        mia_score_list, 
+        membership_list, 
+        offline_a
+    )
+
+    if len(target_model_indices) > 1:
+        logger.info(
+            "DUCI %0.1f seconds", time.time() - baseline_time
+        )
+
+    # Get average prediction errors across all experiments
+    if len(target_model_indices) > 1:
+        logger.info(f"Average prediction errors: agg-MIA baseline {np.mean(agg_mia_baseline)} | DUCI: {np.mean(duci)}")
+
+
+    logger.info("Total runtime: %0.5f seconds", time.time() - start_time)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_duci.py
+++ b/run_duci.py
@@ -106,7 +106,7 @@ def main():
 
     ######################################  Perform DUCI ######################################
     baseline_time = time.time()
-    target_model_indices = list(range(num_experiments))
+    target_model_indices = list(range(2*(num_experiments+1))) # Each run uses one model as target model
 
     ############################  Input your own reference model indices ############################
     #Sample: construct reference models
@@ -125,7 +125,13 @@ def main():
 
 
     logger.info(f"Initiate DUCI for target models: {target_model_indices}")
-    DUCI_instance = DUCI(logger)
+    args = {
+        "attack": "RMIA",
+        "dataset": configs["data"]["dataset"], # TODO: have DUCI config
+        "model": configs["train"]["model_name"],
+        "offline_a": 0.3
+    }
+    DUCI_instance = DUCI(logger, args)
 
     logger.info("Collecting membership prediction for each sample in the target dataset on target models and reference models.")
     logger.info("Predicting the proportion of dataset usage on target models.")

--- a/run_range_mia.py
+++ b/run_range_mia.py
@@ -1,0 +1,141 @@
+"""This file is the main entry point for running the privacy auditing tool."""
+
+import argparse
+import math
+import time
+
+import numpy as np
+import torch
+import yaml
+
+from audit import get_average_audit_results, audit_models, sample_auditing_dataset
+from dataset.range_dataset import RangeDataset, RangeSampler
+from get_signals import get_model_signals
+from models.utils import load_models, train_models, split_dataset_for_training
+from util import (
+    check_configs,
+    setup_log,
+    initialize_seeds,
+    create_directories,
+    load_dataset,
+)
+
+# Enable benchmark mode in cudnn to improve performance when input sizes are consistent
+torch.backends.cudnn.benchmark = True
+
+
+def main():
+    print(20 * "-")
+    print("Privacy Meter Tool!")
+    print(20 * "-")
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(description="Run privacy auditing tool.")
+    parser.add_argument(
+        "--cf",
+        type=str,
+        default="configs/cifar10.yaml",
+        help="Path to the configuration YAML file.",
+    )
+    args = parser.parse_args()
+
+    # Load configuration file
+    with open(args.cf, "rb") as f:
+        configs = yaml.load(f, Loader=yaml.Loader)
+
+    # Validate configurations
+    check_configs(configs)
+
+    # Initialize seeds for reproducibility
+    initialize_seeds(configs["run"]["random_seed"])
+
+    # Create necessary directories
+    log_dir = configs["run"]["log_dir"]
+    directories = {
+        "log_dir": log_dir,
+        "report_dir": f"{log_dir}/report",
+        "signal_dir": f"{log_dir}/signals",
+        "data_dir": configs["data"]["data_dir"],
+    }
+    create_directories(directories)
+
+    # Set up logger
+    logger = setup_log(
+        directories["report_dir"], "time_analysis", configs["run"]["time_log"]
+    )
+
+    start_time = time.time()
+
+    # Load the dataset
+    baseline_time = time.time()
+    dataset = load_dataset(configs, directories["data_dir"], logger)
+    logger.info("Loading dataset took %0.5f seconds", time.time() - baseline_time)
+
+    # Define experiment parameters
+    num_experiments = configs["run"]["num_experiments"]
+    num_reference_models = configs["audit"]["num_ref_models"]
+    num_model_pairs = max(math.ceil(num_experiments / 2.0), num_reference_models + 1)
+
+    # Load or train models
+    baseline_time = time.time()
+    models_list, memberships = load_models(
+        log_dir, dataset, num_model_pairs * 2, configs, logger
+    )
+    if models_list is None:
+        # Split dataset for training two models per pair
+        data_splits, memberships = split_dataset_for_training(
+            len(dataset), num_model_pairs
+        )
+        models_list = train_models(
+            log_dir, dataset, data_splits, memberships, configs, logger
+        )
+    logger.info(
+        "Model loading/training took %0.1f seconds", time.time() - baseline_time
+    )
+
+    auditing_dataset, auditing_membership = sample_auditing_dataset(
+        configs, dataset, logger, memberships
+    )
+
+    auditing_dataset = RangeDataset(auditing_dataset, RangeSampler(configs["ramia"]["range_function"], configs["ramia"]["sample_size"], configs))
+
+    # Generate signals (softmax outputs) for all models
+    baseline_time = time.time()
+    # TODO: Flatten the range auditing dataset to [n*k, d] and get the signals for the auditing dataset
+    signals = get_model_signals(models_list, auditing_dataset, configs, logger)
+    logger.info("Preparing signals took %0.5f seconds", time.time() - baseline_time)
+
+    # Perform the privacy audit
+    baseline_time = time.time()
+    target_model_indices = list(range(num_experiments))
+    # Expand the membership_list to match the shape of the auditing dataset
+    mia_score_list, membership_list = audit_models(
+        f"{directories['report_dir']}/exp",
+        target_model_indices,
+        signals,
+        auditing_membership,
+        num_reference_models,
+        logger,
+        configs,
+    )
+
+    # TODO: postprocess the sample MIA scores to get the range MIA scores
+    mia_score_list = np.array(mia_score_list).reshape(len(auditing_dataset), -1)
+    mia_score_list = mia_score_list
+
+    if len(target_model_indices) > 1:
+        logger.info(
+            "Auditing privacy risk took %0.1f seconds", time.time() - baseline_time
+        )
+
+    # Get average audit results across all experiments
+    if len(target_model_indices) > 1:
+        get_average_audit_results(
+            directories["report_dir"], mia_score_list, membership_list, logger
+        )
+
+    logger.info("Total runtime: %0.5f seconds", time.time() - start_time)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_range_mia.py
+++ b/run_range_mia.py
@@ -97,20 +97,34 @@ def main():
     )
 
     # TODO: abstract the range dataset creation
-    if os.path.exists(f"{directories['data_dir']}/{configs["data"]["dataset"]}_range_auditing.pkl"):
-        with open(f"{directories['data_dir']}/{configs["data"]["dataset"]}_range_auditing.pkl", "rb") as file:
+    if os.path.exists(
+        f"{directories['data_dir']}/{configs["data"]["dataset"]}_range_auditing.pkl"
+    ):
+        with open(
+            f"{directories['data_dir']}/{configs["data"]["dataset"]}_range_auditing.pkl",
+            "rb",
+        ) as file:
             dataset = pickle.load(file)
-        logger.info(f"Load range data from {directories['data_dir']}/{configs["data"]["dataset"]}_range_auditing.pkl")
+        logger.info(
+            f"Load range data from {directories['data_dir']}/{configs["data"]["dataset"]}_range_auditing.pkl"
+        )
     else:
         # Creating the range dataset
         logger.info("Creating range dataset.")
-        dataset = RangeDataset(dataset,
-                               RangeSampler(range_fn=configs["ramia"]["range_function"],
-                                            sample_size=configs["ramia"]["sample_size"],
-                                            config=configs),
-                               configs)
+        dataset = RangeDataset(
+            dataset,
+            RangeSampler(
+                range_fn=configs["ramia"]["range_function"],
+                sample_size=configs["ramia"]["sample_size"],
+                config=configs,
+            ),
+            configs,
+        )
 
-        with open(f"{directories['data_dir']}/{configs["data"]["dataset"]}_range_auditing.pkl", "wb") as f:
+        with open(
+            f"{directories['data_dir']}/{configs["data"]["dataset"]}_range_auditing.pkl",
+            "wb",
+        ) as f:
             pickle.dump(dataset, f)
         logger.info("Range dataset saved to disk.")
 
@@ -128,7 +142,7 @@ def main():
     baseline_time = time.time()
     target_model_indices = list(range(num_experiments))
     # Expand the membership_list to match the shape of the auditing dataset
-    mia_score_list, membership_list = audit_models(
+    mia_score_list, membership_list = audit_models_range(
         f"{directories['report_dir']}/exp",
         target_model_indices,
         signals,
@@ -137,10 +151,6 @@ def main():
         logger,
         configs,
     )
-
-    mia_score_list = np.array(mia_score_list).reshape(len(auditing_dataset), -1)
-    # TODO: abstract the aggregation function
-    mia_score_list = trim_mia_scores(mia_score_list, configs["ramia"]["sample_size"])
 
     if len(target_model_indices) > 1:
         logger.info(

--- a/run_range_mia.py
+++ b/run_range_mia.py
@@ -2,8 +2,6 @@
 
 import argparse
 import math
-import os
-import pickle
 import time
 
 import numpy as np
@@ -95,37 +93,17 @@ def main():
         "Model loading/training took %0.1f seconds", time.time() - baseline_time
     )
 
-    # TODO: abstract the range dataset creation
-    if os.path.exists(
-        f"{directories['data_dir']}/{configs["data"]["dataset"]}_range_auditing.pkl"
-    ):
-        with open(
-            f"{directories['data_dir']}/{configs["data"]["dataset"]}_range_auditing.pkl",
-            "rb",
-        ) as file:
-            dataset = pickle.load(file)
-        logger.info(
-            f"Load range data from {directories['data_dir']}/{configs["data"]["dataset"]}_range_auditing.pkl"
-        )
-    else:
-        # Creating the range dataset
-        logger.info("Creating range dataset.")
-        dataset = RangeDataset(
-            dataset,
-            RangeSampler(
-                range_fn=configs["ramia"]["range_function"],
-                sample_size=configs["ramia"]["sample_size"],
-                config=configs,
-            ),
-            configs,
-        )
-
-        with open(
-            f"{directories['data_dir']}/{configs["data"]["dataset"]}_range_auditing.pkl",
-            "wb",
-        ) as f:
-            pickle.dump(dataset, f)
-        logger.info("Range dataset saved to disk.")
+    # Creating the range dataset
+    logger.info("Creating range dataset.")
+    dataset = RangeDataset(
+        dataset,
+        RangeSampler(
+            range_fn=configs["ramia"]["range_function"],
+            sample_size=configs["ramia"]["sample_size"],
+            config=configs,
+        ),
+        configs,
+    )
 
     # Subsampling the dataset for auditing
     auditing_dataset, auditing_membership = sample_auditing_dataset(

--- a/run_range_mia.py
+++ b/run_range_mia.py
@@ -21,6 +21,7 @@ from util import (
     create_directories,
     load_dataset,
 )
+from ramia_scores import trim_mia_scores
 
 # Enable benchmark mode in cudnn to improve performance when input sizes are consistent
 torch.backends.cudnn.benchmark = True
@@ -139,7 +140,7 @@ def main():
 
     mia_score_list = np.array(mia_score_list).reshape(len(auditing_dataset), -1)
     # TODO: abstract the aggregation function
-    mia_score_list = mia_score_list.mean(axis=1)
+    mia_score_list = trim_mia_scores(mia_score_list, configs["ramia"]["sample_size"])
 
     if len(target_model_indices) > 1:
         logger.info(

--- a/run_range_mia.py
+++ b/run_range_mia.py
@@ -10,7 +10,7 @@ import numpy as np
 import torch
 import yaml
 
-from audit import get_average_audit_results, audit_models, sample_auditing_dataset
+from audit import get_average_audit_results, audit_models_range, sample_auditing_dataset
 from dataset.range_dataset import RangeDataset, RangeSampler
 from get_signals import get_model_signals
 from models.utils import load_models, train_models, split_dataset_for_training
@@ -21,7 +21,6 @@ from util import (
     create_directories,
     load_dataset,
 )
-from ramia_scores import trim_mia_scores
 
 # Enable benchmark mode in cudnn to improve performance when input sizes are consistent
 torch.backends.cudnn.benchmark = True


### PR DESCRIPTION
Original MIA attack can be launched by `MIA.run_mia` using `args["attack"]` to control the attack type (default to be RMIA)

Example:

```
# Each run uses one model as target model and selects reference models from the remaining models
target_model_indices = list(range(2*(num_experiments+1)))
reference_model_indices_all = []
for target_model_idx in target_model_indices:
    paired_model_idx = (
        target_model_idx + 1 if target_model_idx % 2 == 0 else target_model_idx - 1
    )
    # Select reference models from non-target and non-paired model indices
    ref_indices = [
        I
        for i in range(signals.shape[1])
        if i != target_model_idx and i != paired_model_idx
    ][: 2 * num_reference_models]
    reference_model_indices_all.append(np.array(ref_indices))

args = {
        "attack": "RMIA",
        "dataset": configs["data"]["dataset"],
        "model": configs["train"]["model_name"],
        "offline_a": 0.3
    }

# Initialize the MIA instance
MIA_instance = MIA(logger)
mia_scores, target_memberships = MIA_instance.run_mia(
      all_signals, 
      all_memberships, 
      target_model_idx, 
      reference_model_indices, 
      logger, 
      args,
      reuse_offline_a=False
  )
```